### PR TITLE
fix: 🐛 incorrect data fetching and warning under `enforceActions`

### DIFF
--- a/src/view/Home/HomeThree/components/ObserverComponents.tsx
+++ b/src/view/Home/HomeThree/components/ObserverComponents.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Observer, useLocalObservable} from 'mobx-react-lite';
 import {Button} from '@/components';
 import {fetchPokemon} from '@/api/home-two';
+import {runInAction} from 'mobx';
 
 const ObserverHoc = () => {
     /**
@@ -23,9 +24,11 @@ const ObserverHoc = () => {
         async onFetchPokemon() {
             this.loading = true;
             const result: any = await fetchPokemon({limit: 100});
-            const {results} = result;
-            this.list = results;
-            this.loading = false;
+            const {results} = result.data;
+            runInAction(() => {
+                this.list = results;
+                this.loading = false;
+            });
         },
         onChange(item: {name: string; url: string}) {
             // 点击某个条目时，修改该条目的 name，还记得 mobx 使用的是同一份数据吗，这里的更改能影响到列表的数据

--- a/src/view/Home/HomeThree/components/ObserverHoc.tsx
+++ b/src/view/Home/HomeThree/components/ObserverHoc.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {observer, useLocalObservable} from 'mobx-react-lite';
 import {Button} from '@/components';
 import {fetchPokemon} from '@/api/home-two/index';
+import {runInAction} from 'mobx';
 
 const ObserverComponents = () => {
     /**
@@ -23,9 +24,11 @@ const ObserverComponents = () => {
         async onFetchPokemon() {
             this.loading = true;
             const result: any = await fetchPokemon({limit: 100});
-            const {results} = result;
-            this.list = results;
-            this.loading = false;
+            const {results} = result.data;
+            runInAction(() => {
+                this.list = results;
+                this.loading = false;
+            });
         },
         onChange(item: {name: string; url: string}) {
             // 点击某个条目时，修改该条目的 name，还记得 mobx 使用的是同一份数据吗，这里的更改能影响到列表的数据


### PR DESCRIPTION
1. 修复：在`HomeThree`中数据获取不正确的问题
2. 在 `configure({ enforceActions: 'always' })` 下获取数据时的警告问题, `enforceActions` 的目的是确保你不会忘记将事件处理程序包装在 action 中, 通过使用 `runInAction` 来修复这个问题, `runInAction` 允许在异步操作中修改可观察状态，从而避免违反 MobX 的严格模式

Ref: https://stackoverflow.com/questions/57271153/mobx-runinaction-usage-why-do-we-need-it

![Screenshot 2025-02-02 at 3 36 18 PM](https://github.com/user-attachments/assets/8b91837c-7576-4431-ab72-24d57a7220f4)
